### PR TITLE
remove special characters from title when searching. fixes https://github.com/windmilleng/exterminator/issues/6

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,12 @@ function findClubhouseStoryForGithubIssue(issue) {
   // https://github.com/clubhouse/clubhouse-lib/issues/23
   // https://github.com/clubhouse/clubhouse-lib/issues/70
   let title = issue.title
-  return ch.searchStories(title).then(response => {
+
+  // Remove special characters from the title in case they
+  // are search operators.
+  let simplifiedTitle = title.replace(/[^a-zA-Z]/gi, ' ')
+  
+  return ch.searchStories(simplifiedTitle).then(response => {
     let stories = response.data
     return stories.find(story => {
       let links = story.external_tickets || []


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/specialchars:

52caadc5e7502953ab9ec5e42babcf59fdd3acb9 (2020-04-10 10:13:47 -0400)
remove special characters from title when searching. fixes https://github.com/windmilleng/exterminator/issues/6

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics